### PR TITLE
Fix tests subdirectory for ResourceT in Persistent types (SQL/postgres version)

### DIFF
--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -94,3 +94,4 @@ test-suite test
                  , yesod-core
                  , persistent
                  , persistent-postgresql
+                 , resourcet

--- a/tests/HomeTest.hs
+++ b/tests/HomeTest.hs
@@ -4,10 +4,12 @@ module HomeTest
     ) where
 
 import TestImport
+import qualified Data.List as L
 
 homeSpecs :: Specs
 homeSpecs =
-  describe "These are some example tests" $
+  describe "These are some example tests" $ do
+
     it "loads the index and checks it looks right" $ do
       get_ "/"
       statusIs 200
@@ -22,3 +24,12 @@ homeSpecs =
       htmlCount ".message" 1
       htmlAllContain ".message" "Some Content"
       htmlAllContain ".message" "text/plain"
+
+    -- This is a simple example of using a database access in a test.  The
+    -- test will succeed for a fresh scaffolded site with an empty database,
+    -- but will fail on an existing database with a non-empty user table.
+    it "leaves the user table empty" $ do
+      get_ "/"
+      statusIs 200
+      users <- runDB $ selectList ([] :: [Filter User]) []
+      assertEqual "user table empty" 0 $ L.length users

--- a/tests/TestImport.hs
+++ b/tests/TestImport.hs
@@ -1,14 +1,22 @@
 {-# LANGUAGE OverloadedStrings #-}
 module TestImport
     ( module Yesod.Test
+    , module Model
+    , module Database.Persist
     , runDB
     , Specs
     ) where
 
 import Yesod.Test
-import Database.Persist.GenericSql
+import Database.Persist hiding (get)
+import Database.Persist.GenericSql (runSqlPool, SqlPersist, Connection)
+import Control.Monad.Trans.Resource (ResourceT, runResourceT)
+
+import Model
 
 type Specs = SpecsConn Connection
 
-runDB :: SqlPersist IO a -> OneSpec Connection a
-runDB = runDBRunner runSqlPool
+runDB :: SqlPersist (ResourceT IO) a -> OneSpec Connection a
+runDB = runDBRunner poolRunner
+  where
+    poolRunner query pool = runResourceT $ runSqlPool query pool


### PR DESCRIPTION
The _tests_ directory of the scaffolding wasn't updated for using runResourceT in
database accesses.  As well as correcting this, I have added a trivial example test
case to HomeTest.hs, both as a self-test of the fix and to help users get started.
I have chosen to re-export the required things via TestImport.

This _postgres_ version applies to the other SQL database branches too, of course - I'll
do another pull request for the _mongo_ branch, and **none** of this goes into _simple_.

If you would prefer separate pull requests for all the branches, give me a shout - I've
already built and tested them using the tools provided, and pushed them to my fork.
I don't know whether you want to maintain the merging between branches, so I've
tried to err on the simple side for now.
