### PR TITLE
Git ignore cabal dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/


### PR DESCRIPTION
Since `yesod init` already mentions using cabal-dev, it may be useful to add the cabal-dev directory to default .gitignore generated with the scaffolded site.
