### PR TITLE
Ignore .DS_Store files that OS X generates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cabal-dev/
 yesod-devel/
 .cabal-sandbox
 cabal.sandbox.config
+.DS_Store


### PR DESCRIPTION
Not specific to Yesod, but I consider this a reasonable default for a scaffolded .gitignore.
