### PR TITLE
Specify session timeout in minutes

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -58,7 +58,7 @@ instance Yesod App where
     -- Store session data on the client in encrypted cookies,
     -- default session idle timeout is 120 minutes
     makeSessionBackend _ = fmap Just $ defaultClientSessionBackend
-        (120 * 60) -- 120 minutes
+        120    -- timeout in minutes
         "config/client_session_key.aes"
 
     defaultLayout widget = do


### PR DESCRIPTION
Scaffold seems to have been wrong (or at least misleading) for quite a while: defaultClientSessionBackend takes the timeout parameter in minutes!
