### PR TITLE
Adding Prelude to Model.hs so basic datatypes can be used in config/mode...

### DIFF
--- a/Model.hs
+++ b/Model.hs
@@ -4,6 +4,7 @@ import Yesod
 import Data.Text (Text)
 import Database.Persist.Quasi
 import Data.Typeable (Typeable)
+import Prelude
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities


### PR DESCRIPTION
Adding merge request here per: https://github.com/yesodweb/yesod/pull/768

When using an `Int` as a datatype in a scaffolded postgres app we get this error:

```
Model.hs:13:7:
    Not in scope: type constructor or class `Int'
    Perhaps you meant `Ints' (imported from Yesod)
    In the result of the splice:
      $(persistFileWith lowerCaseSettings "config/models")
    To see what the splice expanded to, use -ddump-splices
    In the second argument of `share', namely
      `$(persistFileWith lowerCaseSettings "config/models")'
    In the expression:
      share
        [mkPersist sqlOnlySettings, mkMigrate "migrateAll"]
        ($(persistFileWith lowerCaseSettings "config/models"))
```

Since `Int` is such a common/basic type, and especially because the yesod book uses `Int`s in its most basic Persistent examples, it seems this should work "out of the box"
