### PR TITLE
Model.hs : Add TypeSynonymInstances which is required for persistent 2.0...

### DIFF
--- a/Model.hs
+++ b/Model.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeSynonymInstances #-}
 module Model where
 
 import Yesod


### PR DESCRIPTION
..8.

Without this I get:

```
Model.hs:13:1:
    Illegal instance declaration for
      ‘ToBackendKey
         persistent-2.0.8:Database.Persist.Sql.Types.SqlBackend Email’
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use TypeSynonymInstances if you want to disable this.)
    In the instance declaration for
      ‘ToBackendKey persistent-2.0.8:Database.Persist.Sql.Types.SqlBackend Email’

Model.hs:13:1:
    Illegal instance declaration for
       ‘ToBackendKey
         persistent-2.0.8:Database.Persist.Sql.Types.SqlBackend User’
      (All instance types must be of the form (T t1 ... tn)
       where T is not a synonym.
       Use TypeSynonymInstances if you want to disable this.)
    In the instance declaration for
      ‘ToBackendKey persistent-2.0.8:Database.Persist.Sql.Types.SqlBackend User’
```

I would have commited it directly, but wasn't 100% sure this was right.
