### PR TITLE
Move keter postgres configuration under plugins.

### DIFF
--- a/config/keter.yml
+++ b/config/keter.yml
@@ -53,4 +53,5 @@ stanzas:
 # If you would like to have Keter automatically create a PostgreSQL database
 # and set appropriate environment variables for it to be discovered, uncomment
 # the following line.
-# postgres: true
+# plugins:
+#   postgres: true


### PR DESCRIPTION
This fixes snoyberg/keter#46 for v1.0 Keter config syntax.
