### PR TITLE
Add ViewPatterns extension to Cabal file

### DIFF
--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -40,6 +40,7 @@ library
                 EmptyDataDecls
                 NoMonomorphismRestriction
                 DeriveDataTypeable
+                ViewPatterns
 
     build-depends: base                          >= 4          && < 5
                  , yesod                         >= 1.4.0      && < 1.5


### PR DESCRIPTION
If I understand it right, Yesod 1.4 [adds a dependency on the ViewPatterns extension](http://www.yesodweb.com/blog/2014/09/announcing-yesod-1-4). Without this extension, for a route like `/articles/#Int ArticleR GET` you'll get this error:

```
Foundation.hs:48:1:
    Illegal view pattern:  fromPathPiece -> Just dyn_alQq
    Use ViewPatterns to enable view patterns
```

So it seems right to add that extension to the scaffolding.
