### PR TITLE
MySQL: wipe the database between tests

### DIFF
--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -15,8 +15,11 @@ import Yesod.Test            as X
 
 runDB :: SqlPersistM a -> YesodExample App a
 runDB query = do
-    pool <- fmap appConnPool getTestYesod
-    liftIO $ runSqlPersistMPool query pool
+    app <- getTestYesod
+    liftIO $ runDBWithApp app query
+
+runDBWithApp :: App -> SqlPersistM a -> IO a
+runDBWithApp app query = runSqlPersistMPool query (appConnPool app)
 
 withApp :: SpecWith App -> Spec
 withApp = before $ do
@@ -28,13 +31,18 @@ withApp = before $ do
     wipeDB foundation
     return foundation
 
+-- This function will truncate all of the tables in your database.
+-- 'withApp' calls it before each test, creating a clean environment for each
+-- spec to run in.
 wipeDB :: App -> IO ()
-wipeDB foundation = do
-    let pool = appConnPool foundation
-    flip runSqlPersistMPool pool $ do
+wipeDB app = do
+    runDBWithApp app $ do
         tables <- getTables
         let queries = map ("TRUNCATE TABLE " ++ ) tables
 
+        -- In MySQL, a table cannot be truncated if another table references it via foreign key.
+        -- Since we're wiping both the parent and child tables, though, it's safe
+        -- to temporarily disable this check.
         rawExecute "SET foreign_key_checks = 0;" []
         forM_ queries (\q -> rawExecute q [])
         rawExecute "SET foreign_key_checks = 1;" []

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -6,7 +6,7 @@ module TestImport
 import Application           (makeFoundation)
 import ClassyPrelude         as X
 import Database.Persist      as X hiding (get)
-import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle)
+import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
 import Foundation            as X
 import Model                 as X
 import Test.Hspec            as X
@@ -38,7 +38,8 @@ wipeDB :: App -> IO ()
 wipeDB app = do
     runDBWithApp app $ do
         tables <- getTables
-        let queries = map ("TRUNCATE TABLE " ++ ) tables
+        sqlBackend <- ask
+        let queries = map (\t -> "TRUNCATE TABLE " ++ (connEscapeName sqlBackend $ DBName t)) tables
 
         -- In MySQL, a table cannot be truncated if another table references it via foreign key.
         -- Since we're wiping both the parent and child tables, though, it's safe


### PR DESCRIPTION
Initial implementation of wiping the database for the MySQL backend (I guess I'll end up doing 1 PR per-backend?). Based on testing this works fine, though [the logs](https://gist.github.com/MaxGabriel/87d5ca66a0959df1e761) are a little wonky; sometimes it seems to be missing the last few SQL statements from a test in the logs. For example, these logs are missing the `TRUNCATE TABLE user` and `SET foreign_key_checks = 1` queries:

```
11/Jan/2015:21:14:41 -0800 [Debug#SQL] "SHOW TABLES;" [] @(persistent-2.1.1.3:Database.Persist.Sql.Raw ./Database/Persist/Sql/Raw.hs:42:26)
11/Jan/2015:21:14:41 -0800 [Debug#SQL] "SET foreign_key_checks = 0;" [] @(persistent-2.1.1.3:Database.Persist.Sql.Raw ./Database/Persist/Sql/Raw.hs:64:18)
11/Jan/2015:21:14:41 -0800 [Debug#SQL] "TRUNCATE TABLE email" [] @(persistent-2.1.1.3:Database.Persist.Sql.Raw ./Database/Persist/Sql/Raw.hs:64:18)
Tables are ["email","user"]
11/Jan/2015:21:14:41 -0800 [Debug#SQL] "SHOW TABLES;" [] @(persistent-2.1.1.3:Database.Persist.Sql.Raw ./Database/Persist/Sql/Raw.hs:42:26)
```

It seems to work though, so maybe the logging is just dropping some messages or something.

Probably should wait until I get PRs up for all the backends before merging any, since they'll have some common code.