### PR TITLE
Remove ChromeFrame link from scaffolding; closes #60

### DIFF
--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -40,9 +40,3 @@ $newline never
           \  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
           })();
         }
-    \<!-- Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.  chromium.org/developers/how-tos/chrome-frame-getting-started -->
-    \<!--[if lt IE 7 ]>
-      <script src="//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js">
-      <script>
-        window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})
-    \<![endif]-->


### PR DESCRIPTION
(ChromeFrame has been deprecated for a year or so)