### PR TITLE
Switch from addNonce to addToken; fixes deprecation warning

### DIFF
--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -116,7 +116,7 @@ test-suite test
 
     build-depends: base
                  , PROJECTNAME
-                 , yesod-test >= 1.4.2 && < 1.5
+                 , yesod-test >= 1.4.3 && < 1.5
                  , yesod-core
                  , yesod
                  , persistent

--- a/test/Handler/HomeSpec.hs
+++ b/test/Handler/HomeSpec.hs
@@ -12,7 +12,7 @@ spec = withApp $ do
         request $ do
             setMethod "POST"
             setUrl HomeR
-            addNonce
+            addToken
             fileByLabel "Choose a file" "test/Spec.hs" "text/plain" -- talk about self-reference
             byLabel "What's on the file?" "Some Content"
 


### PR DESCRIPTION
yesod-test 1.4.3 adds `addToken` and deprecates `addNonce`. This switches to the new version.