### PR TITLE
Fix css.map 404 for sqlite branch

### DIFF
--- a/static/css/bootstrap.css
+++ b/static/css/bootstrap.css
@@ -6200,4 +6200,3 @@ button.close {
     display: none !important;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
The bootstrap.css have one line , defined an not exist css.map file
Delete the last line to prevent 404 request

See https://github.com/yesodweb/yesod/issues/934