### PR TITLE
Relax version bounds

### DIFF
--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -63,7 +63,7 @@ library
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1
                  , hjsmin                        >= 0.1        && < 0.2
-                 , monad-control                 >= 0.3        && < 0.4
+                 , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
                  , yaml                          >= 0.8        && < 0.9
                  , http-conduit                  >= 2.1        && < 2.2
@@ -73,7 +73,7 @@ library
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
-                 , fast-logger                   >= 2.2        && < 2.3
+                 , fast-logger                   >= 2.2        && < 2.4
                  , wai-logger                    >= 2.2        && < 2.3
                  , file-embed
                  , safe


### PR DESCRIPTION
Two upper bounds in the generated scaffolding conflicted with the latest Stackage snapshot - relaxing them appears to work fine (tested in the sqlite and MySQL versions)