### PR TITLE
Add missing extensions to .ghci, re-format as multi-line

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,18 @@
 :set -i.:config:dist/build/autogen
 :set -DDEVELOPMENT
-:set -XCPP -XTemplateHaskell -XQuasiQuotes -XTypeFamilies -XFlexibleContexts -XGADTs -XOverloadedStrings -XMultiParamTypeClasses -XGeneralizedNewtypeDeriving -XEmptyDataDecls -XDeriveDataTypeable
+:set -XCPP
+:set -XDeriveDataTypeable
+:set -XEmptyDataDecls
+:set -XFlexibleContexts
+:set -XGADTs
+:set -XGeneralizedNewtypeDeriving
+:set -XMultiParamTypeClasses
+:set -XNoImplicitPrelude
+:set -XNoMonomorphismRestriction
+:set -XOverloadedStrings
+:set -XQuasiQuotes
+:set -XRecordWildCards
+:set -XTemplateHaskell
+:set -XTupleSections
+:set -XTypeFamilies
+:set -XViewPatterns


### PR DESCRIPTION
This file was out of date with the cabal file's extensions list. The missing
extensions were:

- NoImplicitPrelude
- NoMonomorphismRestriction
- RecordWildCards
- TupleSections
- ViewPatterns

I find the multi-line format much easier to manage. It does have a minor 
impact on startup time:

Single-line:

    % time echo ':exit' | ghci
    ...
    ghci  0.23s user 0.02s system 98% cpu 0.246 total

Multi-line:

    % time echo ':exit' | ghci
    ...
    ghci  0.32s user 0.02s system 99% cpu 0.342 total

If this is unacceptable, let me know and I'll join it back up.