### PR TITLE
Draft of using Yesod as an API server to a Javascript frontend

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -34,6 +34,7 @@ import System.Log.FastLogger                (defaultBufSize, newStdoutLoggerSet,
 -- Don't forget to add new modules to your cabal file!
 import Handler.Common
 import Handler.Home
+import Handler.Comment
 
 -- This line actually creates our YesodDispatch instance. It is the second half
 -- of the call to mkYesodData which occurs in Foundation.hs. Please see the

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -9,6 +9,8 @@ import Yesod.Auth.Message   (AuthMessage (InvalidLogin))
 import Yesod.Default.Util   (addStaticContentExternal)
 import Yesod.Core.Types     (Logger)
 import qualified Yesod.Core.Unsafe as Unsafe
+import qualified Data.CaseInsensitive as CI
+import qualified Data.Text.Encoding as TE
 
 -- | The foundation datatype for your application. This can be a good place to
 -- keep settings and values requiring initialization before your application
@@ -53,6 +55,14 @@ instance Yesod App where
     makeSessionBackend _ = Just <$> defaultClientSessionBackend
         120    -- timeout in minutes
         "config/client_session_key.aes"
+
+    -- Yesod Middleware allows you to run code before and after each handler function.
+    -- The defaultYesodMiddleware adds the response header "Vary: Accept, Accept-Language" and performs authorization checks.
+    -- The defaultCsrfMiddleware:
+    --   a) Sets a cookie with a CSRF token in it.
+    --   b) Validates that incoming write requests include that token in either a header or POST parameter.
+    -- For details, see the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package.
+    yesodMiddleware = defaultCsrfMiddleware . defaultYesodMiddleware
 
     defaultLayout widget = do
         master <- getYesod

--- a/Handler/Comment.hs
+++ b/Handler/Comment.hs
@@ -1,0 +1,16 @@
+module Handler.Comment where
+
+import Import
+
+postCommentR :: Handler Value
+postCommentR = do
+    -- requireJsonBody will parse the request body into the appropriate type, or return a 400 status code if the request JSON is invalid.
+    -- (The ToJSON and FromJSON instances are derived in the config/models file).
+    comment <- (requireJsonBody :: Handler Comment)
+
+    -- The YesodAuth instance in Foundation.hs defines the UserId to be the type used for authentication.
+    maybeCurrentUserId <- maybeAuthId
+    let comment' = comment { commentUserId = maybeCurrentUserId }
+
+    insertedComment <- runDB $ insertEntity comment'
+    returnJson insertedComment

--- a/Handler/Home.hs
+++ b/Handler/Home.hs
@@ -3,6 +3,7 @@ module Handler.Home where
 import Import
 import Yesod.Form.Bootstrap3 (BootstrapFormLayout (..), renderBootstrap3,
                               withSmallInput)
+import Text.Julius (RawJS (..))
 
 -- This is a handler function for the GET request method on the HomeR
 -- resource pattern. All of your resource patterns are defined in
@@ -17,6 +18,7 @@ getHomeR = do
     let submission = Nothing :: Maybe (FileInfo, Text)
         handlerName = "getHomeR" :: Text
     defaultLayout $ do
+        let (commentFormId, commentTextareaId, commentListId) = commentIds
         aDomId <- newIdent
         setTitle "Welcome To Yesod!"
         $(widgetFile "homepage")
@@ -30,6 +32,7 @@ postHomeR = do
             _ -> Nothing
 
     defaultLayout $ do
+        let (commentFormId, commentTextareaId, commentListId) = commentIds
         aDomId <- newIdent
         setTitle "Welcome To Yesod!"
         $(widgetFile "homepage")
@@ -38,3 +41,6 @@ sampleForm :: Form (FileInfo, Text)
 sampleForm = renderBootstrap3 BootstrapBasicForm $ (,)
     <$> fileAFormReq "Choose a file"
     <*> areq textField (withSmallInput "What's on the file?") Nothing
+
+commentIds :: (Text, Text, Text)
+commentIds = ("js-commentForm", "js-createCommentTextarea", "js-commentList")

--- a/Model.hs
+++ b/Model.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+
 module Model where
 
 import ClassyPrelude.Yesod

--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -22,6 +22,7 @@ library
                      Settings.StaticFiles
                      Handler.Common
                      Handler.Home
+                     Handler.Comment
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
@@ -49,7 +50,7 @@ library
 
     build-depends: base                          >= 4          && < 5
                  , yesod                         >= 1.4.1      && < 1.5
-                 , yesod-core                    >= 1.4.6      && < 1.5
+                 , yesod-core                    >= 1.4.14     && < 1.5
                  , yesod-auth                    >= 1.4.0      && < 1.5
                  , yesod-static                  >= 1.4.0.3    && < 1.6
                  , yesod-form                    >= 1.4.0      && < 1.5
@@ -82,6 +83,7 @@ library
                  , containers
                  , vector
                  , time
+                 , case-insensitive
                  , wai
 
 executable         PROJECTNAME
@@ -119,7 +121,7 @@ test-suite test
 
     build-depends: base
                  , PROJECTNAME
-                 , yesod-test >= 1.5 && < 1.6
+                 , yesod-test >= 1.5.0.1 && < 1.6
                  , yesod-core
                  , yesod
                  , persistent
@@ -131,3 +133,4 @@ test-suite test
                  , hspec >= 2.0.0
                  , classy-prelude
                  , classy-prelude-yesod
+                 , aeson

--- a/config/models
+++ b/config/models
@@ -5,8 +5,13 @@ User
     deriving Typeable
 Email
     email Text
-    user UserId Maybe
+    userId UserId Maybe
     verkey Text Maybe
     UniqueEmail email
+Comment json -- Adding "json" causes ToJSON and FromJSON instances to be derived.
+    message Text
+    userId UserId Maybe
+    deriving Eq
+    deriving Show
 
  -- By default this file is used in Model.hs (which is imported by Foundation.hs)

--- a/config/routes
+++ b/config/routes
@@ -5,3 +5,5 @@
 /robots.txt RobotsR GET
 
 / HomeR GET POST
+
+/comments CommentR POST

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -19,6 +19,26 @@ $newline never
     \<!--[if lt IE 9]>
     \<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     \<![endif]-->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.3/js.cookie.min.js">
+
+    <script>
+      /* The `defaultCsrfMiddleware` Middleware added in Foundation.hs adds a CSRF token the request cookies. */
+      /* AJAX requests should add that token to a header to be validated by the server. */
+      /* See the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package for details. */
+      var csrfHeaderName = "#{TE.decodeUtf8 $ CI.foldedCase defaultCsrfHeaderName}";
+
+      var csrfCookieName = "#{TE.decodeUtf8 defaultCsrfCookieName}";
+      var csrfToken = Cookies.get(csrfCookieName);
+
+
+      if (csrfToken) {
+      \  $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
+      \      if (!options.crossDomain) {
+      \          jqXHR.setRequestHeader(csrfHeaderName, csrfToken);
+      \      }
+      \  });
+      }
 
     <script>
       document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/,'js');

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -36,6 +36,16 @@
          Send it! <span class="glyphicon glyphicon-upload"></span>
   <hr />
 
+  <li> Yesod has JSON support baked-in. The form below makes an AJAX request with Javascript, then updates the page with your submission. (see <em>Handler/Comment.hs</em>, <em>templates/homepage.julius</em>, and <em>Handler/Home.hs</em> for the implementation).
+    <form ##{commentFormId}>
+      <div .form-group>
+        <textarea ##{commentTextareaId} placeholder="Your comment here..." required></textarea>
+      <button .btn .btn-primary type="submit">
+        Create comment
+      
+    
+    <ul ##{commentListId}>
+
   <li> And last but not least, Testing. In <em>test/Spec.hs</em> you will find a #
     test suite that performs tests on this page. #
     You can run your tests by doing: <pre>yesod test</pre>

--- a/templates/homepage.julius
+++ b/templates/homepage.julius
@@ -1,1 +1,31 @@
 document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by the Javascript part of the homepage widget.";
+
+$(function() {
+  $("##{rawJS commentFormId}").submit(function(event) {
+    event.preventDefault();
+
+    var message = $("##{rawJS commentTextareaId}").val();
+    // (Browsers that enforce the "required" attribute on the textarea won't see this alert)
+    if (!message) {
+      alert("Please fill out the comment form first.");
+      return;
+    }
+
+    // Make an AJAX request to the server to create a new comment
+    $.ajax({
+      url: '@{CommentR}',
+      type: 'POST',
+      contentType: "application/json",
+      data: JSON.stringify({
+        message: message,
+      }),
+      success: function (data) {
+        $("##{rawJS commentListId}").append("<li>" + data.message + "</li>");
+      },
+      error: function (data) {
+        console.log("Error creating comment: " + data);
+      },
+    });
+
+  });
+});

--- a/templates/homepage.lucius
+++ b/templates/homepage.lucius
@@ -18,3 +18,8 @@ footer {
 .input-sm {
     margin-left: 20px
 }
+
+##{commentTextareaId} {
+    width: 400px;
+    height: 100px;
+}

--- a/test/Handler/CommentSpec.hs
+++ b/test/Handler/CommentSpec.hs
@@ -1,0 +1,41 @@
+module Handler.CommentSpec (spec) where
+
+import TestImport
+import Data.Aeson
+
+spec :: Spec
+spec = withApp $ do
+    describe "valid request" $ do
+        it "gives a 200" $ do
+            get HomeR
+            statusIs 200
+
+            let message = "My message" :: Text
+                body = object [ "message" .= message ]
+                encoded = encode body
+
+            request $ do
+                setMethod "POST"
+                setUrl CommentR
+                setRequestBody encoded
+                addRequestHeader ("Content-Type", "application/json")
+                addTokenFromCookie
+            
+            statusIs 200
+
+            [Entity _id comment] <- runDB $ selectList [CommentMessage ==. message] []
+            assertEqual "Should have " comment (Comment message Nothing)
+
+    describe "invalid requests" $ do
+        it "400s when the JSON body is invalid" $ do
+            get HomeR
+
+            let body = object [ "foo" .= ("My message" :: Value) ]
+            request $ do
+                setMethod "POST"
+                setUrl CommentR
+                setRequestBody $ encode body
+                addRequestHeader ("Content-Type", "application/json")
+                addTokenFromCookie
+            statusIs 400
+


### PR DESCRIPTION
In #73 there was some discussion about adding an example of using Yesod as an API server. I took a quick stab at that; this PR just adds a link you can click on the homepage, which triggers an AJAX request to the server to create a new user. The server inserts the user into the database and returns the data to the client, which updates adds the user to an `<ul>`.

Is this roughly what we're looking for? I wrote functions to request all users and to delete specific ones as well, if we want to add more API server example code.