### PR TITLE
Document that mkYesodData generates the Handler and Widget type synonyms

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -31,6 +31,10 @@ instance HasHttpManager App where
 -- Note that this is really half the story; in Application.hs, mkYesodDispatch
 -- generates the rest of the code. Please see the linked documentation for an
 -- explanation for this split.
+--
+-- This function also generates the following type synonyms:
+-- type Handler = HandlerT App IO
+-- type Widget = WidgetT App IO ()
 mkYesodData "App" $(parseRoutesFile "config/routes")
 
 -- | A convenient synonym for creating forms.


### PR DESCRIPTION
Potential solution for yesodweb/yesod#985

I think that adding a comment with the exact text of the type synonyms is just as good for discoverability as making the type synonyms directly from the scaffolding. It also avoids the hassle of adding another function or making a breaking change.

Thoughts?