### PR TITLE
Document 'copy-to-args' option in keter.yml

### DIFF
--- a/config/keter.yml
+++ b/config/keter.yml
@@ -53,6 +53,12 @@ stanzas:
 # keter`. Uses `scp` internally, so you can set it to a remote destination
 # copy-to: user@host:/opt/keter/incoming
 
+# You can pass arguments to `scp` used above. This example limits bandwidth to
+# 1024 Kbit/s and uses port 2222 instead of the default 22
+# copy-to-args:
+#   - "-l 1024"
+#   - "-P 2222"
+
 # If you would like to have Keter automatically create a PostgreSQL database
 # and set appropriate environment variables for it to be discovered, uncomment
 # the following line.


### PR DESCRIPTION
As added in [yesodweb/yesod/#970](https://github.com/yesodweb/yesod/pull/970)