### PR TITLE
Add trailing slash to example 'copy-to' destination in keter.yml

### DIFF
--- a/config/keter.yml
+++ b/config/keter.yml
@@ -51,7 +51,7 @@ stanzas:
 
 # Use the following to automatically copy your bundle upon creation via `yesod
 # keter`. Uses `scp` internally, so you can set it to a remote destination
-# copy-to: user@host:/opt/keter/incoming
+# copy-to: user@host:/opt/keter/incoming/
 
 # You can pass arguments to `scp` used above. This example limits bandwidth to
 # 1024 Kbit/s and uses port 2222 instead of the default 22


### PR DESCRIPTION
Without a trailing slash, the bundle might be written to a *file* named `incoming` if the `incoming` directory doesn't exist.