### PR TITLE
core(gitignore): add stack work to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/client_session_key.aes
 *.sqlite3-wal
 .hsenv*
 cabal-dev/
+.stack-work/
 yesod-devel/
 .cabal-sandbox
 cabal.sandbox.config


### PR DESCRIPTION
Hi,

It seems with this issue (https://github.com/commercialhaskell/stack/issues/247) that the `.stack-work` directory should be in the `.gitignore` file? Am I right?

Tell me if it's not the case and if there are other stack related files to add to the `.gitignore` file.

Thanks.