### PR TITLE
upgrade to yesod-test-1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+ghc: 7.8
+
+addons:
+  postgresql: "9.3"
+  #apt:
+  #  sources:
+  #  - hvr-ghc
+  #  packages:
+  #  - ghc-7.10.2
+
+before_install:
+  # stack
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:/opt/ghc/7.10.2/bin:$PATH
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.3.1/stack-0.1.3.1-x86_64-linux.gz | gunzip > ~/.local/bin/stack
+  - chmod a+x ~/.local/bin/stack
+
+script:
+  - travis_retry curl -L https://raw.githubusercontent.com/yesodweb/yesod-scaffold/master/stack/postgres.yaml > stack.yaml
+  - stack build --test --no-run-tests
+
+cache:
+  directories:
+    - $HOME/.stack

--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -82,6 +82,7 @@ library
                  , containers
                  , vector
                  , time
+                 , wai
 
 executable         PROJECTNAME
     if flag(library-only)
@@ -118,7 +119,7 @@ test-suite test
 
     build-depends: base
                  , PROJECTNAME
-                 , yesod-test >= 1.4.3 && < 1.5
+                 , yesod-test >= 1.5 && < 1.6
                  , yesod-core
                  , yesod
                  , persistent

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -3,7 +3,7 @@ module TestImport
     , module X
     ) where
 
-import Application           (makeFoundation)
+import Application           (makeFoundation, makeLogWare)
 import ClassyPrelude         as X
 import Database.Persist      as X hiding (get)
 import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
@@ -23,7 +23,7 @@ runDBWithApp :: App -> SqlPersistM a -> IO a
 runDBWithApp app query = runSqlPersistMPool query (appConnPool app)
 
 
-withApp :: SpecWith App -> Spec
+withApp :: SpecWith (TestApp App) -> Spec
 withApp = before $ do
     settings <- loadAppSettings
         ["config/test-settings.yml", "config/settings.yml"]
@@ -31,7 +31,8 @@ withApp = before $ do
         ignoreEnv
     foundation <- makeFoundation settings
     wipeDB foundation
-    return foundation
+    logWare <- liftIO $ makeLogWare foundation
+    return (foundation, logWare)
 
 -- This function will truncate all of the tables in your database.
 -- 'withApp' calls it before each test, creating a clean environment for each


### PR DESCRIPTION
Integration tests will perform application logging to stdout
This means you can actually figure out why your tests are failing.

A downside is a lot of output interleaved with your tests.
We should address that downside in a future change.
I already have something working locally that I want to try out
for a few weeks and refine a bit.