### PR TITLE
hack to get the .travis.yml to work on a branch

### DIFF
--- a/stack/postgres.yaml
+++ b/stack/postgres.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+  - '.'
+resolver: nightly-2015-08-21
+extra-deps:
+  - yesod-test-1.5


### PR DESCRIPTION
travis can curl for postgres's stack
Probably should instead have a concept of ignored files