### PR TITLE
base-noprelude instead of NoImplicitPrelude

### DIFF
--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -18,6 +18,7 @@ library
                      Import
                      Import.NoFoundation
                      Model
+                     Prelude
                      Settings
                      Settings.StaticFiles
                      Handler.Common
@@ -48,7 +49,7 @@ library
                 TupleSections
                 RecordWildCards
 
-    build-depends: base                          >= 4          && < 5
+    build-depends: base-noprelude                >= 4          && < 5
                  , yesod                         >= 1.4.1      && < 1.5
                  , yesod-core                    >= 1.4.14     && < 1.5
                  , yesod-auth                    >= 1.4.0      && < 1.5
@@ -92,7 +93,7 @@ executable         PROJECTNAME
 
     main-is:           main.hs
     hs-source-dirs:    app
-    build-depends:     base, PROJECTNAME
+    build-depends:     base-noprelude, PROJECTNAME
 
     ghc-options:       -threaded -O2 -rtsopts -with-rtsopts=-N
 
@@ -119,7 +120,7 @@ test-suite test
                 ViewPatterns
                 TupleSections
 
-    build-depends: base
+    build-depends: base-noprelude
                  , PROJECTNAME
                  , yesod-test >= 1.5.0.1 && < 1.6
                  , yesod-core

--- a/Prelude.hs
+++ b/Prelude.hs
@@ -1,0 +1,3 @@
+module Prelude (module ClassyPrelude) where
+
+import ClassyPrelude


### PR DESCRIPTION
This is a path to address the main problem from #109. Although I am not sure if as it currently stands it will create a problem from exporting a `Prelude` module.

base-noprelude serves the same end but avoids using a language extension

If we like this direction,
The setup should be altered so that Prelude.hs is Import.NoFoundation