### PR TITLE
Warn that `port` in settings.yml isn't for yesod devel

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@
 
 static-dir:     "_env:STATIC_DIR:static"
 host:           "_env:HOST:*4" # any IPv4 host
-port:           "_env:PORT:3000"
+port:           "_env:PORT:3000" # NB: The port `yesod devel` uses is distinct from this value. Set the `yesod devel` port from the command line.
 approot:        "_env:APPROOT:http://localhost:3000"
 ip-from-header: "_env:IP_FROM_HEADER:false"
 


### PR DESCRIPTION
* Would help address the confusion here: https://github.com/yesodweb/yesod/issues/1109

Should `wai-devel` be mentioned here as well?