### PR TITLE
remove "autogen-" prefix

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -107,7 +107,7 @@ instance Yesod App where
             content
       where
         -- Generate a unique filename based on the content itself
-        genFileName lbs = "autogen-" ++ base64md5 lbs
+        genFileName = base64md5
 
     -- What messages should be logged. The following includes all messages when
     -- in development, and warnings and errors in production.


### PR DESCRIPTION
There is no reason to prefix autogen, the files are already put into a
dir called tmp and their name is a hash, that's pretty clear.  Omitting
the prefix saves some bytes in every css and in every html including a css.