### PR TITLE
Patch templates so they don't require CSRF

### DIFF
--- a/test/Handler/CommentSpec.hs
+++ b/test/Handler/CommentSpec.hs
@@ -19,8 +19,7 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
-            
+
             statusIs 200
 
             [Entity _id comment] <- runDB $ selectList [CommentMessage ==. message] []
@@ -31,11 +30,12 @@ spec = withApp $ do
             get HomeR
 
             let body = object [ "foo" .= ("My message" :: Value) ]
+
             request $ do
                 setMethod "POST"
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
+
             statusIs 400
 


### PR DESCRIPTION
The `Handler.Comment` specs fail, because of a call to `addTokenFromCookie`,
but no `defaultCsrfMiddleware` on `Foundation.hs` [1]

This removes all calls to `addTokenFromCookie` from the yesod templates'
tests.

This closes commercialhaskell/stack-templates#71 and is related to PR
commercialhaskell/stack-templates#72.

[1] - https://github.com/commercialhaskell/stack-templates/blob/master/yesod-postgres.hsfiles#L289

Also could be fixed with as mentioned in commercialhaskell/stack-templates#71:

```
-    yesodMiddleware = defaultYesodMiddleware
+    yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
```