### PR TITLE
Add auth Dummy in development mode

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -35,6 +35,7 @@ import System.Log.FastLogger                (defaultBufSize, newStdoutLoggerSet,
 import Handler.Common
 import Handler.Home
 import Handler.Comment
+import Handler.Profile
 
 -- This line actually creates our YesodDispatch instance. It is the second half
 -- of the call to mkYesodData which occurs in Foundation.hs. Please see the

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -153,8 +153,8 @@ instance YesodAuth App where
 
     -- You can add other plugins like Google Email, email or OAuth here
     authPlugins app = [authOpenId Claimed []] ++ extraAuthPlugins
-        -- Enable authDummy login when in development mode.
-        where extraAuthPlugins = [authDummy | appDevelopment $ appSettings app]
+        -- Enable authDummy login if enabled.
+        where extraAuthPlugins = [authDummy | appAuthDummyLogin $ appSettings app]
 
 
 

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -4,6 +4,8 @@ import Import.NoFoundation
 import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Text.Hamlet          (hamletFile)
 import Text.Jasmine         (minifym)
+import Yesod.Auth.Dummy
+-- ^ Used only when in development mode.
 import Yesod.Auth.OpenId    (authOpenId, IdentifierType (Claimed))
 import Yesod.Default.Util   (addStaticContentExternal)
 import Yesod.Core.Types     (Logger)
@@ -85,10 +87,13 @@ instance Yesod App where
 
     -- Routes not requiring authentication.
     isAuthorized (AuthR _) _ = return Authorized
+    isAuthorized CommentR _ = return Authorized
+    isAuthorized HomeR _ = return Authorized
     isAuthorized FaviconR _ = return Authorized
     isAuthorized RobotsR _ = return Authorized
-    -- Default to Authorized for now.
-    isAuthorized _ _ = return Authorized
+    isAuthorized (StaticR _) _ = return Authorized
+
+    isAuthorized ProfileR _ = isAuthenticated
 
     -- This function creates static content files in the static folder
     -- and names them based on a hash of their content. This allows
@@ -147,9 +152,21 @@ instance YesodAuth App where
                 }
 
     -- You can add other plugins like Google Email, email or OAuth here
-    authPlugins _ = [authOpenId Claimed []]
+    authPlugins app = [authOpenId Claimed []] ++ extraAuthPlugins
+      -- Enable authDummy login when in development mode.
+      where extraAuthPlugins = [authDummy | appDevelopment $ appSettings app]
+
+
 
     authHttpManager = getHttpManager
+
+-- | Access function to determine if a user is logged in.
+isAuthenticated :: Handler AuthResult
+isAuthenticated = do
+    mu <- maybeAuthId
+    return $ case mu of
+        Nothing -> Unauthorized "You must login to access this page"
+        Just _ -> Authorized
 
 instance YesodAuthPersist App
 

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -156,8 +156,6 @@ instance YesodAuth App where
         -- Enable authDummy login if enabled.
         where extraAuthPlugins = [authDummy | appAuthDummyLogin $ appSettings app]
 
-
-
     authHttpManager = getHttpManager
 
 -- | Access function to determine if a user is logged in.

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -153,8 +153,8 @@ instance YesodAuth App where
 
     -- You can add other plugins like Google Email, email or OAuth here
     authPlugins app = [authOpenId Claimed []] ++ extraAuthPlugins
-      -- Enable authDummy login when in development mode.
-      where extraAuthPlugins = [authDummy | appDevelopment $ appSettings app]
+        -- Enable authDummy login when in development mode.
+        where extraAuthPlugins = [authDummy | appDevelopment $ appSettings app]
 
 
 
@@ -163,8 +163,8 @@ instance YesodAuth App where
 -- | Access function to determine if a user is logged in.
 isAuthenticated :: Handler AuthResult
 isAuthenticated = do
-    mu <- maybeAuthId
-    return $ case mu of
+    mAuthId <- maybeAuthId
+    return $ case mAuthId of
         Nothing -> Unauthorized "You must login to access this page"
         Just _ -> Authorized
 

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -163,8 +163,8 @@ instance YesodAuth App where
 -- | Access function to determine if a user is logged in.
 isAuthenticated :: Handler AuthResult
 isAuthenticated = do
-    mAuthId <- maybeAuthId
-    return $ case mAuthId of
+    muid <- maybeAuthId
+    return $ case muid of
         Nothing -> Unauthorized "You must login to access this page"
         Just _ -> Authorized
 

--- a/Foundation.hs
+++ b/Foundation.hs
@@ -5,7 +5,7 @@ import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Text.Hamlet          (hamletFile)
 import Text.Jasmine         (minifym)
 import Yesod.Auth.Dummy
--- ^ Used only when in development mode.
+-- ^ Used only when in "auth-dummy-login" setting is enabled.
 import Yesod.Auth.OpenId    (authOpenId, IdentifierType (Claimed))
 import Yesod.Default.Util   (addStaticContentExternal)
 import Yesod.Core.Types     (Logger)

--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -6,5 +6,5 @@ getProfileR :: Handler Html
 getProfileR = do
     (_, user) <- requireAuthPair
     defaultLayout $ do
-        setTitle . toHtml $ userIdent user `mappend` "'s User page"
+        setTitle . toHtml $ userIdent user <> "'s User page"
         $(widgetFile "profile")

--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -4,7 +4,7 @@ import Import
 
 getProfileR :: Handler Html
 getProfileR = do
-  (_, user) <- requireAuthPair
-  defaultLayout $ do
-    setTitle . toHtml $ userIdent user `mappend` "'s User page"
-    $(widgetFile "profile")
+    (_, user) <- requireAuthPair
+    defaultLayout $ do
+        setTitle . toHtml $ userIdent user `mappend` "'s User page"
+        $(widgetFile "profile")

--- a/Handler/Profile.hs
+++ b/Handler/Profile.hs
@@ -1,0 +1,10 @@
+module Handler.Profile where
+
+import Import
+
+getProfileR :: Handler Html
+getProfileR = do
+  (_, user) <- requireAuthPair
+  defaultLayout $ do
+    setTitle . toHtml $ userIdent user `mappend` "'s User page"
+    $(widgetFile "profile")

--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -132,7 +132,7 @@ test-suite test
     build-depends: base
                  , PROJECTNAME
                  , yesod-auth
-                 , yesod-test >= 1.5.0.1 && < 1.6
+                 , yesod-test >= 1.5.2 && < 1.6
                  , yesod-core
                  , yesod
                  , persistent

--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -23,6 +23,7 @@ library
                      Handler.Common
                      Handler.Home
                      Handler.Comment
+                     Handler.Profile
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
@@ -101,6 +102,7 @@ test-suite test
     other-modules:     Handler.CommentSpec
                        Handler.CommonSpec
                        Handler.HomeSpec
+                       Handler.ProfileSpec
                        TestImport
     hs-source-dirs:    test
     ghc-options:       -Wall
@@ -124,6 +126,7 @@ test-suite test
 
     build-depends: base
                  , PROJECTNAME
+                 , yesod-auth
                  , yesod-test >= 1.5.0.1 && < 1.6
                  , yesod-core
                  , yesod

--- a/Settings.hs
+++ b/Settings.hs
@@ -55,8 +55,8 @@ data AppSettings = AppSettings
     , appAnalytics              :: Maybe Text
     -- ^ Google Analytics code
 
-    , appDevelopment            :: Bool
-    -- ^ Indicate if we are in development mode
+    , appAuthDummyLogin         :: Bool
+    -- ^ Indicate if auth dummy login should be enabled.
     }
 
 instance FromJSON AppSettings where
@@ -80,10 +80,11 @@ instance FromJSON AppSettings where
         appMutableStatic          <- o .:? "mutable-static"   .!= defaultDev
         appSkipCombining          <- o .:? "skip-combining"   .!= defaultDev
 
-        appCopyright              <- o .: "copyright"
+        appCopyright              <- o .:  "copyright"
         appAnalytics              <- o .:? "analytics"
 
-        appDevelopment            <- o .:? "development"      .!= defaultDev
+        appAuthDummyLogin         <- o .:? "auth-dummy-login"      .!= defaultDev
+
         return AppSettings {..}
 
 -- | Settings for 'widgetFile', such as which template languages to support and

--- a/Settings.hs
+++ b/Settings.hs
@@ -54,6 +54,9 @@ data AppSettings = AppSettings
     -- ^ Copyright text to appear in the footer of the page
     , appAnalytics              :: Maybe Text
     -- ^ Google Analytics code
+
+    , appDevelopment            :: Bool
+    -- ^ Indicate if we are in development mode
     }
 
 instance FromJSON AppSettings where
@@ -80,6 +83,7 @@ instance FromJSON AppSettings where
         appCopyright              <- o .: "copyright"
         appAnalytics              <- o .:? "analytics"
 
+        appDevelopment            <- o .:? "development"      .!= defaultDev
         return AppSettings {..}
 
 -- | Settings for 'widgetFile', such as which template languages to support and

--- a/config/routes
+++ b/config/routes
@@ -7,4 +7,5 @@
 / HomeR GET POST
 
 /comments CommentR POST
+
 /profile ProfileR GET

--- a/config/routes
+++ b/config/routes
@@ -7,3 +7,4 @@
 / HomeR GET POST
 
 /comments CommentR POST
+/profile ProfileR GET

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,12 +13,12 @@ ip-from-header: "_env:IP_FROM_HEADER:false"
 # Optional values with the following production defaults.
 # In development, they default to the inverse.
 #
-# development: false
 # detailed-logging: false
 # should-log-all: false
 # reload-templates: false
 # mutable-static: false
 # skip-combining: false
+# auth-dummy-login : false
 
 # NB: If you need a numeric value (e.g. 123) to parse as a String, wrap it in single quotes (e.g. "_env:PGPASS:'123'")
 # See https://github.com/yesodweb/yesod/wiki/Configuration#parsing-numeric-values-as-strings

--- a/config/test-settings.yml
+++ b/config/test-settings.yml
@@ -7,3 +7,5 @@ database:
   #
   #   database: "_env:PGDATABASE:PROJECTNAME_LOWER_test"
   database: PROJECTNAME_LOWER_test
+
+development: true

--- a/config/test-settings.yml
+++ b/config/test-settings.yml
@@ -8,4 +8,4 @@ database:
   #   database: "_env:PGDATABASE:PROJECTNAME_LOWER_test"
   database: PROJECTNAME_LOWER_test
 
-development: true
+auth-dummy-login: true

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -21,6 +21,12 @@
     <tt>config/routes
 
   <span .list-group-item>
+    We can link to other handlers, like the <a href="@{ProfileR}">Profile</a>. Try it out as an anonymous user and see
+    the access denied. Then, try to <a href="@{AuthR LoginR}">login</a> with the dummy authentication added
+    while in development.
+
+
+  <span .list-group-item>
     The HTML you are seeing now is actually composed by a number of <em>widgets</em>, #
     most of them are brought together by the <tt>defaultLayout</tt> function which #
     is defined in the <tt>Foundation.hs</tt> module, and used by <tt>#{handlerName}</tt>. #

--- a/templates/profile.hamlet
+++ b/templates/profile.hamlet
@@ -2,5 +2,7 @@
   You got access!
 
 <p>
-  This page is protected and access is allowed only for anonymous users.
-  You data is protected with us <span class="username">#{userIdent user}</span>!
+  This page is protected and access is allowed only for authenticated users.
+
+<p>
+  Your data is protected with us <strong><span class="username">#{userIdent user}</span></strong>!

--- a/templates/profile.hamlet
+++ b/templates/profile.hamlet
@@ -1,5 +1,5 @@
 <h1>
-  You got access!
+  Access granted!
 
 <p>
   This page is protected and access is allowed only for authenticated users.

--- a/templates/profile.hamlet
+++ b/templates/profile.hamlet
@@ -1,0 +1,6 @@
+<h1>
+  You got access!
+
+<p>
+  This page is protected and access is allowed only for anonymous users.
+  You data is protected with us <span class="username">#{userIdent user}</span>!

--- a/test/Handler/ProfileSpec.hs
+++ b/test/Handler/ProfileSpec.hs
@@ -6,21 +6,21 @@ spec :: Spec
 spec = withApp $ do
 
     describe "Profile page" $ do
-      it "asserts no access to my-account for anonymous users" $ do
-        get ProfileR
-        statusIs 403
+        it "asserts no access to my-account for anonymous users" $ do
+            get ProfileR
+            statusIs 403
 
-      it "asserts access to my-account for authenticated users" $ do
-        user <- createUser "foo"
-        authenticateAs user
+        it "asserts access to my-account for authenticated users" $ do
+            userEntity <- createUser "foo"
+            authenticateAs userEntity
 
-        get ProfileR
-        statusIs 200
+            get ProfileR
+            statusIs 200
 
-      it "asserts user's information is shown" $ do
-        user <- createUser "bar"
-        authenticateAs user
+        it "asserts user's information is shown" $ do
+            userEntity <- createUser "bar"
+            authenticateAs userEntity
 
-        get ProfileR
-        let (Entity _ u) = user
-        htmlAnyContain ".username" . unpack $ userIdent u
+            get ProfileR
+            let (Entity _ user) = userEntity
+            htmlAnyContain ".username" . unpack $ userIdent user

--- a/test/Handler/ProfileSpec.hs
+++ b/test/Handler/ProfileSpec.hs
@@ -1,0 +1,26 @@
+module Handler.ProfileSpec (spec) where
+
+import TestImport
+
+spec :: Spec
+spec = withApp $ do
+
+    describe "Profile page" $ do
+      it "asserts no access to my-account for anonymous users" $ do
+        get ProfileR
+        statusIs 403
+
+      it "asserts access to my-account for authenticated users" $ do
+        user <- createUser "foo"
+        authenticateAs user
+
+        get ProfileR
+        statusIs 200
+
+      it "asserts user's information is shown" $ do
+        user <- createUser "bar"
+        authenticateAs user
+
+        get ProfileR
+        let (Entity _ u) = user
+        htmlAnyContain ".username" . unpack $ userIdent u

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -57,8 +57,8 @@ getTables = do
 
     return $ map unSingle tables
 
--- | Authenticate as a user. This uses the fact that in test-settings.yaml we
--- set the "development" to True, this the auth dummy is enabled.
+-- | Authenticate as a user. This relies on the `development: true` flag being set in test-settings.yaml,
+-- which enables dummy authentication in Foundation.hs
 authenticateAs :: Entity User -> YesodExample App ()
 authenticateAs (Entity _ u) = do
     request $ do
@@ -69,7 +69,7 @@ authenticateAs (Entity _ u) = do
 -- | Create a user.
 createUser :: Text -> YesodExample App (Entity User)
 createUser ident = do
-  runDB $ insertEntity User
-    { userIdent = ident
-    , userPassword = Nothing
-    }
+    runDB $ insertEntity User
+        { userIdent = ident
+        , userPassword = Nothing
+        }

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -12,6 +12,7 @@ import Model                 as X
 import Test.Hspec            as X
 import Text.Shakespeare.Text (st)
 import Yesod.Default.Config2 (useEnv, loadYamlSettings)
+import Yesod.Auth            as X
 import Yesod.Test            as X
 
 runDB :: SqlPersistM a -> YesodExample App a
@@ -55,3 +56,20 @@ getTables = do
     |] []
 
     return $ map unSingle tables
+
+-- | Authenticate as a user. This uses the fact that in test-settings.yaml we
+-- set the "development" to True, this the auth dummy is enabled.
+authenticateAs :: Entity User -> YesodExample App ()
+authenticateAs (Entity _ u) = do
+    request $ do
+        setMethod "POST"
+        addPostParam "ident" $ userIdent u
+        setUrl $ AuthR $ PluginR "dummy" []
+
+-- | Create a user.
+createUser :: Text -> YesodExample App (Entity User)
+createUser ident = do
+  runDB $ insertEntity User
+    { userIdent = ident
+    , userPassword = Nothing
+    }

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -57,8 +57,9 @@ getTables = do
 
     return $ map unSingle tables
 
--- | Authenticate as a user. This relies on the `development: true` flag being set in test-settings.yaml,
--- which enables dummy authentication in Foundation.hs
+-- | Authenticate as a user. This relies on the `auth-dummy-login: true` flag
+-- being set in test-settings.yaml, which enables dummy authentication in
+-- Foundation.hs
 authenticateAs :: Entity User -> YesodExample App ()
 authenticateAs (Entity _ u) = do
     request $ do


### PR DESCRIPTION
PR does a bunch of closely related stuff:

1. Add `appDevelopment` setting
1. Add auth dummy login, whenever in development mode
1. Add a route that can be access only by authenticated user. While doing so, also make each route's authorization explicit
1. Extend the tests to show how to login a user

Homepage:

![welcome_to_yesod_](https://cloud.githubusercontent.com/assets/125707/18178504/4aee19b4-7087-11e6-8a44-15a26a92db55.jpg)

Profile page (authenticated user):

![amitaibu_s_user_page_and_haskell-programming-0_11_2-screen_pdf](https://cloud.githubusercontent.com/assets/125707/18178569/8c67eef6-7087-11e6-8759-cc9707019fbb.jpg)

btw, to confirm there isn't a better way - I had to scaffold to another directory, do the changes, and then copy back to this repo. 
Also, there doesn't seem to be a `stack test` in this repo - is there a way to properly check my code ?