### PR TITLE
Use mysql library in a thread-safe manner

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE RankNTypes           #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Application
     ( getApplicationDev
@@ -13,15 +15,22 @@ module Application
     , db
     ) where
 
+#if MIN_VERSION_base(4,9,0)
+import Control.Concurrent                   (forkOSWithUnmask)
+#else
+import GHC.IO                               (unsafeUnmask)
+#endif
 import Control.Monad.Logger                 (liftLoc, runLoggingT)
 import Database.Persist.MySQL               (createMySQLPool, myConnInfo,
                                              myPoolSize, runSqlPool)
+import qualified Database.MySQL.Base as MySQL
 import Import
 import Language.Haskell.TH.Syntax           (qLocation)
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp             (Settings, defaultSettings,
                                              defaultShouldDisplayException,
                                              runSettings, setHost,
+                                             setFork, setOnOpen, setOnClose,
                                              setOnException, setPort, getPort)
 import Network.Wai.Middleware.RequestLogger (Destination (Logger),
                                              IPAddrSource (..),
@@ -55,6 +64,9 @@ makeFoundation appSettings = do
     appStatic <-
         (if appMutableStatic appSettings then staticDevel else static)
         (appStaticDir appSettings)
+
+    -- See http://www.yesodweb.com/blog/2016/11/use-mysql-safely-in-yesod
+    MySQL.initLibrary
 
     -- We need a log function to create a connection pool. We need a connection
     -- pool to create our foundation. And we need our foundation to get a
@@ -101,8 +113,14 @@ makeLogWare foundation =
         , destination = Logger $ loggerSet $ appLogger foundation
         }
 
+#if !  MIN_VERSION_base(4,9,0)
+forkOSWithUnmask :: ((forall a . IO a -> IO a) -> IO ()) -> IO ThreadId
+forkOSWithUnmask io = forkOS (io unsafeUnmask)
+#endif
 
 -- | Warp settings for the given foundation value.
+-- Use bound threads for thread-safe use of MySQL, and initialise and finalise
+-- them: see http://www.yesodweb.com/blog/2016/11/use-mysql-safely-in-yesod
 warpSettings :: App -> Settings
 warpSettings foundation =
       setPort (appPort $ appSettings foundation)
@@ -115,6 +133,9 @@ warpSettings foundation =
             "yesod"
             LevelError
             (toLogStr $ "Exception from Warp: " ++ show e))
+    $ setFork (\x -> void $ forkOSWithUnmask x)
+    $ setOnOpen (const $ MySQL.initThread >> return True)
+    $ setOnClose (const MySQL.endThread)
       defaultSettings
 
 -- | For yesod devel, return the Warp settings and WAI Application.

--- a/PROJECTNAME.cabal
+++ b/PROJECTNAME.cabal
@@ -66,7 +66,7 @@ library
                  , text                          >= 0.11       && < 2.0
                  , persistent                    >= 2.0        && < 2.7
                  , persistent-mysql              >= 2.1.2      && < 2.7
-                 , mysql
+                 , mysql                         >= 0.1.4
                  , persistent-template           >= 2.0        && < 2.7
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1


### PR DESCRIPTION
Here are the changes to the *mysql scaffolding only* for thread-safe use of the mysql library, further to #139 .

This will very shortly be accompanied by a PR to add a blog post to yesodweb.com-content.  That post is meant to provide the documentation, so the comments in the code simply refer to it.

The conditional compilation and other baggage needed to define forkOSWithUnmask for base<4.9.0 is an absolute pain :-(  
