### PR TITLE
Setting Text fields to be varchar(255) in MySQL

### DIFF
--- a/config/models
+++ b/config/models
@@ -4,12 +4,12 @@ User
     UniqueUser ident
     deriving Typeable
 Email
-    email Text
+    email Text sqltype=varchar(255)
     userId UserId Maybe sqltype=varchar(255) default=NULL
     verkey Text Maybe sqltype=varchar(255) default=NULL
     UniqueEmail email
 Comment json -- Adding "json" causes ToJSON and FromJSON instances to be derived.
-    message Text
+    message Text sqltype=varchar(255)
     userId UserId Maybe sqltype=varchar(255) default=NULL
     deriving Eq
     deriving Show

--- a/config/models
+++ b/config/models
@@ -1,16 +1,16 @@
 User
-    ident Text
-    password Text Maybe default=NULL
+    ident Text sqltype=varchar(255)
+    password Text Maybe sqltype=varchar(255) default=NULL
     UniqueUser ident
     deriving Typeable
 Email
     email Text
-    userId UserId Maybe default=NULL
-    verkey Text Maybe default=NULL
+    userId UserId Maybe sqltype=varchar(255) default=NULL
+    verkey Text Maybe sqltype=varchar(255) default=NULL
     UniqueEmail email
 Comment json -- Adding "json" causes ToJSON and FromJSON instances to be derived.
     message Text
-    userId UserId Maybe default=NULL
+    userId UserId Maybe sqltype=varchar(255) default=NULL
     deriving Eq
     deriving Show
 


### PR DESCRIPTION
On some MySQL versions, Text fields cannot be NULL and display the following message:

> BLOB/TEXT column 'password' can't have a default value

This pull request solves that.