### PR TITLE
Add `ViewPatterns` to allow routes with params

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Foundation where
 
 import Import.NoFoundation


### PR DESCRIPTION
Otherwise, routes with params didn’t work (e.g. `/user/#UserId`). We would get the error:

```
$ src/Foundation.hs:58:1: error:
    Illegal view pattern:  fromPathPiece -> Just dyn_amz5
    Use ViewPatterns to enable view patterns
```