### PR TITLE
Added bootstrap.js from a CDN to make navbar collapse and uncollapse to work.

### DIFF
--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -22,6 +22,9 @@ $newline never
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.3/js.cookie.min.js">
 
+    \<!-- Bootstrap-3.3.7 compiled and minified JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
+
     <script>
       /* The `defaultCsrfMiddleware` Middleware added in Foundation.hs adds a CSRF token the request cookies. */
       /* AJAX requests should add that token to a header to be validated by the server. */


### PR DESCRIPTION
This template includes only the `bootstrap.css` file, so lines like the following doesn't work. This is from the `default-layout.hamlet` that comes with the template:
    
    <button type="button" .navbar-toggle.collapsed data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">

To solve this I put a `<script src="...` in the `default-layout-wrapper.hamlet`, so it gets the `bootstrap.js` from a CDN. 