### PR TITLE
Replace PROJECTNAME_LOWER before PROJECTNAME

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -111,6 +111,6 @@ createHsFiles root fp branch = do
     -- Replace the PROJECTNAME and PROJECTNAME_LOWER syntax for something Stack
     -- supports
     replaceProjectName = encodeUtf8
-                       . T.replace "PROJECTNAME_LOWER" "{{name}}"
                        . T.replace "PROJECTNAME" "{{name}}"
+                       . T.replace "PROJECTNAME_LOWER" "{{name}}"
                        . decodeUtf8


### PR DESCRIPTION
An issue with the current scaffolding is that `PROJECTNAME_LOWER` isn't replaced correctly. If you run:

`stack new test-keys yesod-postgres`

then you'll get output like this in the `settings.yml` file:

```
  user:     "_env:PGUSER:test-keys_LOWER"
  password: "_env:PGPASS:test-keys"
```

I'm pretty sure what's going on is that `PROJECTNAME` is being replaced first, so then the replace for `PROJECTNAME_LOWER` doesn't work.

I also see there's a [`to-stack-templates.sh`](https://github.com/yesodweb/yesod-scaffold/blob/master/to-stack-templates.sh) file that appears to implement this behavior, but I can't find it referenced anywhere in this repo. Possibly it's unused and can be deleted? 

This change is untested, but I think you can just look at the changed code and tell whether or not it's the correct thing to do.

I tried to test the code but the instructions in the README didn't work for me—I ran `stack build` but `stack exec yesod-scaffold-build` can't find an executable with that name. I don't see `yesod-scaffold-build` anywhere in the repo but in the README, so possibly those are just outdated instructions?