### PR TITLE
Allow adding a __.travis.yml file that will become .travis.yml for the end user

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -96,6 +96,7 @@ createHsFiles root fp branch = do
     runConduitRes
         $ mapM_ (yield . toPair. unpack) (lines (decodeUtf8 files))
        .| filterC (not . isTravis)
+       .| mapC (renameTravis)
        .| createTemplate
        .| mapC replaceProjectName
        .| sinkFile fp
@@ -107,6 +108,11 @@ createHsFiles root fp branch = do
     -- to the yesod-scaffold repo somewhat
     isTravis (".travis.yml", _) = True
     isTravis _ = False
+
+    -- Rename the __.travis.yml file intended for the user's project to .travis.yml
+    renameTravis :: (FilePath, ResourceT IO ByteString) -> (FilePath, ResourceT IO ByteString)
+    renameTravis ("__.travis.yml", x) = (".travis.yml", x)
+    renameTravis a = a
 
     -- Replace the PROJECTNAME and PROJECTNAME_LOWER syntax for something Stack
     -- supports


### PR DESCRIPTION
This is required to solve the issue in #137.

I wrote out a generalized version of this as well, that would take any file with two underscores, remove the old file without two underscores, then rename the double unscored file to remove the underscores. This seemed like too much complexity to be worth it though, since I think this would only apply to a handful of files ever (mostly CI service files).