### PR TITLE
Link to Template Haskell syntax for models and routes file

### DIFF
--- a/config/models
+++ b/config/models
@@ -1,3 +1,6 @@
+-- By default this file is used by `persistFileWith` in Model.hs (which is imported by Foundation.hs)
+-- Syntax for this file here: https://github.com/yesodweb/persistent/blob/master/docs/Persistent-entity-syntax.md
+
 User
     ident Text
     password Text Maybe
@@ -13,5 +16,3 @@ Comment json -- Adding "json" causes ToJSON and FromJSON instances to be derived
     userId UserId Maybe
     deriving Eq
     deriving Show
-
- -- By default this file is used in Model.hs (which is imported by Foundation.hs)

--- a/config/routes
+++ b/config/routes
@@ -1,3 +1,6 @@
+-- By default this file is used by `parseRoutesFile` in Foundation.hs
+-- Syntax for this file here: https://www.yesodweb.com/book/routing-and-handlers
+
 /static StaticR Static appStatic
 /auth   AuthR   Auth   getAuth
 
@@ -9,6 +12,3 @@
 /comments CommentR POST
 
 /profile ProfileR GET
-
--- By default this file is used by `parseRoutesFile` in Foundation.hs
--- Syntax for this file here: https://www.yesodweb.com/book/routing-and-handlers

--- a/config/routes
+++ b/config/routes
@@ -9,3 +9,6 @@
 /comments CommentR POST
 
 /profile ProfileR GET
+
+-- By default this file is used by `parseRoutesFile` in Foundation.hs
+-- Syntax for this file here: https://www.yesodweb.com/book/routing-and-handlers


### PR DESCRIPTION
Since the routes and models files have a custom syntax, I thought it'd be nice to link to the files for the syntax for them.

For the routes file I don't think it's super important, but it's a nice to have (routing is simple, explained in full by the Yesod book, and has limited options). The models syntax though has extensive configuration options and is hidden away, so it's more important to link to it.