### PR TITLE
Add README to scaffolded project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-## Getting Started
-
-Refer to the [Yesod Quickstart guide](https://www.yesodweb.com/page/quickstart) for install instructions.
-
 ## Database Setup
 
 After installing Postgres, run:
@@ -11,6 +7,15 @@ createuser PROJECTNAME_LOWER --password PROJECTNAME --superuser
 createdb PROJECTNAME_LOWER
 createdb PROJECTNAME_LOWER_test
 ```
+
+## Haskell Setup
+
+1. If you haven't already, [install Stack](https://haskell-lang.org/get-started)
+	* On POSIX systems, this is usually `curl -sSL https://get.haskellstack.org/ | sh`
+2. Install the `yesod` command line tool: `stack install yesod-bin --install-ghc`
+3. Build libraries: `stack build`
+
+If you have trouble, refer to the [Yesod Quickstart guide](https://www.yesodweb.com/page/quickstart) for additional detail.
 
 ## Development
 
@@ -28,12 +33,12 @@ As your code changes, your site will be automatically be recompiled and redeploy
 stack test --flag PROJECTNAME_LOWER:library-only --flag PROJECTNAME_LOWER:dev
 ```
 
-(Because `yesod devel` passes the `library-only` and `dev` flags, matching those flags means you don't need to recompile between tests and development, and it disables optimization to speed up your tests).
+(Because `yesod devel` passes the `library-only` and `dev` flags, matching those flags means you don't need to recompile between tests and development, and it disables optimization to speed up your test compile times).
 
 ## Documentation
 
 * Read the [Yesod Book](https://www.yesodweb.com/book) online for free
-* Check [Stackage](http://stackage.org/) for documentation on the packages in your LTS Haskell version, or [search it using Hoogle](https://www.stackage.org/lts-9.14/hoogle?q=)
+* Check [Stackage](http://stackage.org/) for documentation on the packages in your LTS Haskell version, or [search it using Hoogle](https://www.stackage.org/lts/hoogle?q=). Tip: Your LTS version is in your `stack.yaml` file.
 * For local documentation, use:
 	* `stack haddock --open` to generate Haddock documentation for your dependencies, and open that documentation in a browser
 	* `stack hoogle <function, module or type signature>` to generate a Hoogle database and search for your query

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+## Getting Started
+
+Refer to the [Yesod Quickstart guide](https://www.yesodweb.com/page/quickstart) for install instructions.
+
+## Database Setup
+
+After installing Postgres, run:
+
+```
+createuser PROJECTNAME_LOWER --password PROJECTNAME --superuser
+createdb PROJECTNAME_LOWER
+createdb PROJECTNAME_LOWER_test
+```
+
+## Development
+
+Start a development server with:
+
+```
+stack exec -- yesod devel
+```
+
+As your code changes, your site will be automatically be recompiled and redeployed to localhost.
+
+## Tests
+
+```
+stack test --flag PROJECTNAME_LOWER:library-only --flag PROJECTNAME_LOWER:dev
+```
+
+(Because `yesod devel` passes the `library-only` and `dev` flags, matching those flags means you don't need to recompile between tests and development, and it disables optimization to speed up your tests).
+
+## Documentation
+
+* Read the [Yesod Book](https://www.yesodweb.com/book) online for free
+* Check [Stackage](http://stackage.org/) for documentation on the packages in your LTS Haskell version, or [search it using Hoogle](https://www.stackage.org/lts-9.14/hoogle?q=)
+* For local documentation, use:
+	* `stack haddock --open` to generate Haddock documentation for your dependencies, and open that documentation in a browser
+	* `stack hoogle <function, module or type signature>` to generate a Hoogle database and search for your query
+* The [Yesod cookbook](https://github.com/yesodweb/yesod-cookbook) has sample code for various needs
+
+## Getting Help
+
+* Ask questions on [Stack Overflow, using the Yesod or Haskell tags](https://stackoverflow.com/questions/tagged/yesod+haskell) 
+* Ask the [Yesod Google Group](https://groups.google.com/forum/#!forum/yesodweb)
+* There are several chatrooms you can ask for help:
+	* For IRC, try Freenode#yesod and Freenode#haskell
+	* [Functional Programming Slack](https://fpchat-invite.herokuapp.com/), in the #haskell, #haskell-beginners, or #yesod channels.


### PR DESCRIPTION
Addresses part of #137 

I think a README would be a really good addition to the scaffolded project. It would help new users get started, and provide a foundation of documentation for adding other people to your project. IIRC, generating a README is pretty standard other scaffoldings I've seen.

Suggested additions or changes to this README are welcome.

The only potential hassle here is providing database-specific setup instructions.