### PR TITLE
Add foregin-store: Fix compile error for lts-10

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ dependencies:
 - time
 - case-insensitive
 - wai
+- foreign-store
 
 # The library contains all of our application code. The executable
 # defined below is just a thin wrapper.


### PR DESCRIPTION
Right now, you get this error when you build:

```
[1 of 3] Compiling DevelMain        ( app/DevelMain.hs, .stack-work/dist/x86_64-linux/Cabal-2.0.1.0/build/todo/todo-tmp/DevelMain.o ) [Foreign.Store changed]

/home/sibi/todo/app/DevelMain.hs:40:1: error:
    Could not find module ‘Foreign.Store’
    Perhaps you meant
      Foreign.Ptr (from base-4.10.1.0)
      Foreign.Safe (from base-4.10.1.0)
      Foreign.Storable (from base-4.10.1.0)
    Use -v to see a list of the files searched for.
   |
40 | import Foreign.Store
   | ^^^^^^^^^^^^^^^^^^^^
```

My PR just adds the appropriate package in the package.yaml file.