### PR TITLE
Add ViewPatterns to Application.hs

### DIFF
--- a/src/Application.hs
+++ b/src/Application.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Application


### PR DESCRIPTION
As soon as you add a new route which accepts an input, you will be
greeted with this error:

```
/home/sibi/todo/src/Application.hs:49:1: error:
    Illegal view pattern:  fromPathPiece -> Just dyn_awHr
    Use ViewPatterns to enable view patterns
   |
49 | mkYesodDispatch "App" resourcesApp
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

And since defining a route taking inputs is a common task, we should
add this extension by default in the file.