### PR TITLE
Remove Functor constraint from DB synonym

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -65,7 +65,7 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 
 -- | A convenient synonym for database access functions.
 type DB a = forall (m :: * -> *).
-    (MonadIO m, Functor m) => ReaderT SqlBackend m a
+    (MonadIO m) => ReaderT SqlBackend m a
 
 -- Please see the documentation for the Yesod typeclass. There are a number
 -- of settings which can be configured by overriding methods here.


### PR DESCRIPTION
Since MonadIO implies `m` is a `Monad`, and all `Monad`s are `Functor`s, the constraint is unnecessary.