### PR TITLE
Postgres createuser command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 After installing Postgres, run:
 
 ```
-createuser PROJECTNAME_LOWER --password PROJECTNAME --superuser
+createuser PROJECTNAME_LOWER --pwprompt --superuser
+# Enter password PROJECTNAME when prompted
 createdb PROJECTNAME_LOWER
 createdb PROJECTNAME_LOWER_test
 ```


### PR DESCRIPTION
The `createuser` command in the readme did not work for me.  The `--password` option is for the user running the create command, not the password for the user being created:

```
-W
--password
    Force createuser to prompt for a password (for connecting to the server, not for the 
    password of the new user).

    This option is never essential, since createuser will automatically prompt for a 
    password if the server demands password authentication. However, createuser will 
    waste a connection attempt finding out that the server wants a password. In some 
    cases it is worth typing -W to avoid the extra connection attempt.
```

I don't think there is any way to supply the new user password in the command, so I am suggesting `--pwprompt`:

```
-P
--pwprompt
    If given, createuser will issue a prompt for the password of the new user. This is not 
    necessary if you do not plan on using password authentication.
```