### PR TITLE
Support {{name-as-module}} via PROJECTNAME_MODULE

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -160,4 +160,5 @@ createHsFiles root fp branch = do
           return $ encodeUtf8
                  $ T.replace "PROJECTNAME" "{{name}}"
                  $ T.replace "PROJECTNAME_LOWER" "{{name}}"
+                 $ T.replace "PROJECTNAME_MODULE" "{{name-as-module}}"
                    text


### PR DESCRIPTION
I wanted to be able to create module names based on the project name.  `stack new` already supports this through `{{name-as-module}}`.  When name is `my-project`, name-as-module is `Myproject`.  This change uses `PROJECTNAME_MODULE` as the placeholder for this variable.

I tried out this change and the postgres branch built fine using this new placeholder as a module name, file name, and directory name.