### PR TITLE
replace ClassyPrelude with RIO in simple

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,13 +4,17 @@ version: "0.0.0"
 dependencies:
 
 - base >=4.9.1.0 && <5
+
 - yesod >=1.6 && <1.7
 - yesod-core >=1.6 && <1.7
 - yesod-static >=1.6 && <1.7
 - yesod-form >=1.6 && <1.7
-- classy-prelude >=1.5 && <1.6
-- classy-prelude-conduit >=1.5 && <1.6
-- classy-prelude-yesod >=1.5 && <1.6
+
+- rio >= 0.1.8.0
+- http-types
+- persistent
+- yesod-newsfeed
+
 - bytestring >=0.10 && <0.11
 - text >=0.11 && <2.0
 - template-haskell

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -1,10 +1,20 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Import.NoFoundation
-    ( module Import
+    ( module X
     ) where
 
-import ClassyPrelude.Yesod   as Import
-import Settings              as Import
-import Settings.StaticFiles  as Import
-import Yesod.Core.Types      as Import (loggerSet)
-import Yesod.Default.Config2 as Import
+import RIO.Yesod                    as X
+import Data.Default                 as X (Default (..))
+import Database.Persist.Sql         as X (runMigration)
+import Database.Persist.Sql         as X (SqlBackend, SqlPersistT)
+import Network.HTTP.Client.Conduit  as X hiding (Proxy(..))
+import Network.HTTP.Types           as X
+import Settings                     as X
+import Settings.StaticFiles         as X
+import Yesod                        as X hiding (Header, parseTime)
+import Yesod.Core.Types             as X (loggerSet)
+import Yesod.Default.Config2        as X
+import Yesod.Feed                   as X
+import Yesod.Static                 as X

--- a/src/RIO/Yesod.hs
+++ b/src/RIO/Yesod.hs
@@ -1,0 +1,20 @@
+module RIO.Yesod
+  ( module RIO
+  ) where
+
+import RIO
+  hiding
+   ( Handler(..)
+   , LogLevel(..)
+   , LogSource
+   , logDebug
+   , logDebugS
+   , logError
+   , logErrorS
+   , logInfo
+   , logInfoS
+   , logOther
+   , logOtherS
+   , logWarn
+   , logWarnS
+   )

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -10,10 +10,11 @@
 -- declared in the Foundation.hs file.
 module Settings where
 
-import ClassyPrelude.Yesod
+import RIO.Yesod
 import qualified Control.Exception as Exception
-import Data.Aeson                  (Result (..), fromJSON, withObject, (.!=),
-                                    (.:?))
+import Data.Aeson                  (Result (..), FromJSON(..), fromJSON,
+                                    withObject,(.:),(.!=),(.:?),Value(..))
+import Data.Default                (def)
 import Data.FileEmbed              (embedFile)
 import Data.Yaml                   (decodeEither')
 import Language.Haskell.TH.Syntax  (Exp, Name, Q)
@@ -21,6 +22,10 @@ import Network.Wai.Handler.Warp    (HostPreference)
 import Yesod.Default.Config2       (applyEnvValue, configSettingsYml)
 import Yesod.Default.Util          (WidgetFileSettings, widgetFileNoReload,
                                     widgetFileReload)
+import Yesod.Core.Types            (Route)
+import Yesod.Static                (CombineSettings,combineScripts',
+                                    combineStylesheets', Static)
+
 
 -- | Runtime settings to configure this application. These settings can be
 -- loaded from various sources: defaults, environment variables, config files,

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -7,7 +7,7 @@ module TestImport
     ) where
 
 import Application           (makeFoundation, makeLogWare)
-import ClassyPrelude         as X hiding (Handler)
+import RIO                   as X hiding (Handler)
 import Foundation            as X
 import Test.Hspec            as X
 import Yesod.Default.Config2 (useEnv, loadYamlSettings)


### PR DESCRIPTION
CF: yesodweb/yesod#1602
CC: @snoyberg

This template takes `simple` and replaces `classy-prelude-*`
with `rio`. 

Some points:

  * `http-types`, `yesod-newsfeed` and `persistent` was added with
    no bounds restrictions &mdash; what restrictions should we use
    on these packages?
  * `rio >= 0.1.8.0` : is my starting point &mdash; can we relax the
    upper bound? What upper bound should we use?
  * To get `rio` to work with the current stack I am hiding parts of the
    `rio` logging system (I guess these will be addressed by
    [this work](https://github.com/yesodweb/yesod/issues/1602#issuecomment-496503671)).

I am out of time this weekend and I have not had time to build and instantiate the template. I will happily do so later in the week (Friday) if nobody has done so by then.