### PR TITLE
Warn that TRUNCATEing many tables with Postgres can become slow

### DIFF
--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -52,6 +52,10 @@ wipeDB app = runDBWithApp app $ do
     tables <- getTables
     sqlBackend <- ask
 
+    -- TRUNCATEing all tables is the simplest approach to wiping the database.
+    -- Should your application grow to hundreds of tables and tests,
+    -- switching to DELETE could be a substantial speedup.
+    -- See: https://github.com/yesodweb/yesod-scaffold/issues/201
     let escapedTables = map (connEscapeName sqlBackend . DBName) tables
         query = "TRUNCATE TABLE " ++ intercalate ", " escapedTables
     rawExecute query []


### PR DESCRIPTION
I think the vast, vast majority of yesod-scaffold users will never grow to the size where they need to care about this. But for the handful that do, it should save them a lot of time dredging through stackoverflow and postgres mailing lists about this.

I could have made a wiki page about this and cleaned it all up, but I think it's not really worth it for how much of an edge case this is. To reach this point, you need to be a pretty advanced Yesod user, and reading through #201 should be no problem for you

Closes https://github.com/yesodweb/yesod-scaffold/issues/201