### PR TITLE
WIP: Update deps for lts 18.10 -- Issue #205

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,9 +14,9 @@ dependencies:
 - classy-prelude-yesod >=1.5 && <1.6
 - bytestring >=0.10 && <0.11
 - text >=0.11 && <2.0
-- persistent >=2.9 && <2.11
-- persistent-postgresql >=2.9 && <2.11
-- persistent-template >=2.5 && <2.9
+- persistent >=2.9 && <2.14
+- persistent-postgresql >=2.9 && <2.14
+- persistent-template >=2.5 && <2.13
 - template-haskell
 - shakespeare >=2.0 && <2.1
 - hjsmin >=0.1 && <0.3


### PR DESCRIPTION
Issue #205 

My plan of attack was as follows:
- run yesod-scaffold build
- check error message like:
```
    persistent version 2.13.1.2 found
        - PROJECTNAME requires >=2.9 && <2.11
```
- bump dep to next minor version -- error says `2.13.1.2 found`, so bumped `<2.11` to `<2.14`

However I also ran into this error:
```
    classy-prelude-yesod not found
        - PROJECTNAME requires ==1.5.*
```

I guess `classy-prelude-yesod` doesn't ship with `lts 18.10`, and I don't see a stack.yaml at the root level of the project that I could add `extra-deps` to.

Sorry I couldn't get further than this! Any guidance on how to get passed this dependence on `classy-prelude-yesod`?
My guess is that possible paths forward are:
- try bumping to a lower lts
- update `classy-prelude-yesod` to work with `lts 18.10`
- figure out a way to add `extra-deps` to the scaffold

Thoughts? Thanks in advance
