### PR TITLE
Remove `.dir-locals.el` file

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,0 @@
-((haskell-mode . ((haskell-indent-spaces . 4)
-                  (haskell-process-use-ghci . t)))
- (hamlet-mode . ((hamlet/basic-offset . 4)
-                 (haskell-process-use-ghci . t))))


### PR DESCRIPTION
I believe the `.dir-locals.el` file should be removed for the following reasons:

1. It's editor-specific
2. The variable `haskell-indent-spaces` isn't used anymore. It had initially been added in https://github.com/haskell/haskell-mode/commit/d881aa3a671b78825c64b6e14bd025a08a45a1ea but the last remnants of it have been removed in https://github.com/haskell/haskell-mode/pull/1567.
3. I also couldn't find anything about `haskell-process-use-ghci`. It seems to have been part of a custom setup à la https://stackoverflow.com/a/27385914.
4. `hamlet/basic-offset` seems to come from [`hamlet-mode`](https://github.com/lightquake/hamlet-mode). Since there is [`shakespeare-mode`](https://github.com/CodyReichert/shakespeare-mode) which also supports the other Shakespearean template languages, I don't see a reason to set this variable be default.