### PR TITLE
Fix syntax in Haddock comment

### DIFF
--- a/app/DevelMain.hs
+++ b/app/DevelMain.hs
@@ -6,7 +6,7 @@
 --
 -- 1. Start up GHCi
 --
--- $ stack ghci PROJECTNAME:lib --no-load --work-dir .stack-work-devel
+-- > $ stack ghci PROJECTNAME:lib --no-load --work-dir .stack-work-devel
 --
 -- 2. Load this module
 --


### PR DESCRIPTION
Without the `>`, the line

```
-- $ stack ghci PROJECTNAME:lib --no-load --work-dir .stack-work-devel
```

is interpreted as a [named chunk](https://haskell-haddock.readthedocs.io/latest/markup.html#named-chunks).

This means the documentation isn't displayed properly:

<img width="1233" height="250" alt="Screenshot 2026-03-12 at 18 23 17" src="https://github.com/user-attachments/assets/e7918f7a-7e08-4990-97b3-ddc70ca351de" />


It also causes issues with code formatters (try running `DevelMain.hs` through [`ormolu`](https://ormolu-live.tweag.io/) or [`fourmolu`](https://fourmolu.github.io/) and observe that the comment does not stay intact).